### PR TITLE
fix(engine): Button rotation for 2 players

### DIFF
--- a/packages/engine/src/actions/dealing.ts
+++ b/packages/engine/src/actions/dealing.ts
@@ -290,7 +290,9 @@ export function handleDeal(state: GameState, action: DealAction): GameState {
 
 /**
  * Move button to next seat
- * Dead Button Rule: Moves to next index regardless of player presence
+ *
+ * Dead Button Rule (3+ players): Moves to next index regardless of player presence.
+ * Heads-up (2 players): Button must land on an occupied seat.
  */
 function moveButton(state: GameState): number {
   if (state.buttonSeat === null) {
@@ -303,7 +305,26 @@ function moveButton(state: GameState): number {
     return 0;
   }
 
-  // Simply increment seat index (Dead Button)
-  // We do not skip empty seats here.
+  // Count seated players to determine button movement rule
+  const seatedCount = state.players.filter((p) => p !== null).length;
+
+  if (seatedCount <= 2) {
+    // Heads-up: Button must land on an occupied seat
+    // Find the next occupied seat after current button
+    let seat = getNextSeat(state.buttonSeat, state.maxPlayers);
+    const startSeat = state.buttonSeat;
+
+    while (seat !== startSeat) {
+      if (state.players[seat] !== null && state.players[seat]!.stack > 0) {
+        return seat;
+      }
+      seat = getNextSeat(seat, state.maxPlayers);
+    }
+
+    // Fallback: keep button where it is (shouldn't happen with valid 2-player game)
+    return state.buttonSeat;
+  }
+
+  // 3+ players: Dead Button Rule - advance regardless of occupancy
   return getNextSeat(state.buttonSeat, state.maxPlayers);
 }

--- a/packages/engine/tests/integration/buttonRotation.test.ts
+++ b/packages/engine/tests/integration/buttonRotation.test.ts
@@ -1,0 +1,124 @@
+import { PokerEngine } from "../../src/engine/PokerEngine";
+import { ActionType, Street } from "@pokertools/types";
+
+/**
+ * Helper to play a hand to showdown via check/call actions
+ */
+function playHandToShowdown(engine: PokerEngine): void {
+  let iterations = 0;
+  while (engine.state.street !== Street.SHOWDOWN && iterations < 100) {
+    iterations++;
+    const actionTo = engine.state.actionTo;
+    if (actionTo === null) break;
+
+    const player = engine.state.players[actionTo];
+    if (!player) break;
+
+    try {
+      engine.act({ type: ActionType.CHECK, playerId: player.id });
+    } catch {
+      try {
+        engine.act({ type: ActionType.CALL, playerId: player.id });
+      } catch {
+        break;
+      }
+    }
+  }
+}
+
+describe("Button Rotation", () => {
+  test("wraps around in heads-up with sparse seating (9-seat table)", () => {
+    const engine = new PokerEngine({
+      smallBlind: 10,
+      bigBlind: 20,
+      maxPlayers: 9, // 9-seat table
+    });
+
+    // Players at seats 0 and 1 only
+    engine.sit(0, "p1", "Alice", 1000);
+    engine.sit(1, "p2", "Bob", 1000);
+
+    // Hand 1
+    engine.deal();
+    expect(engine.state.buttonSeat).toBe(0);
+    playHandToShowdown(engine);
+
+    // Hand 2
+    engine.deal();
+    expect(engine.state.buttonSeat).toBe(1);
+    playHandToShowdown(engine);
+
+    // Hand 3 - should wrap to seat 0, not crash
+    engine.deal();
+    expect(engine.state.buttonSeat).toBe(0);
+    expect(engine.state.actionTo).not.toBeNull();
+  });
+
+  test("wraps around in heads-up with non-adjacent seating", () => {
+    const engine = new PokerEngine({
+      smallBlind: 10,
+      bigBlind: 20,
+      maxPlayers: 6,
+    });
+
+    // Players at seats 0 and 5 (non-adjacent on 6-seat table)
+    engine.sit(0, "p1", "Alice", 1000);
+    engine.sit(5, "p2", "Bob", 1000);
+
+    // Hand 1
+    engine.deal();
+    expect(engine.state.buttonSeat).toBe(0);
+    playHandToShowdown(engine);
+
+    // Hand 2 - should move to seat 5 (skip empty seats 1-4)
+    engine.deal();
+    expect(engine.state.buttonSeat).toBe(5);
+    playHandToShowdown(engine);
+
+    // Hand 3 - should wrap to seat 0
+    engine.deal();
+    expect(engine.state.buttonSeat).toBe(0);
+  });
+
+  test("dead button rule applies with 3+ players", () => {
+    const engine = new PokerEngine({
+      smallBlind: 10,
+      bigBlind: 20,
+      maxPlayers: 9,
+    });
+
+    // Players at seats 0, 2, 4 (gaps between them)
+    engine.sit(0, "p1", "Alice", 1000);
+    engine.sit(2, "p2", "Bob", 1000);
+    engine.sit(4, "p3", "Charlie", 1000);
+
+    engine.deal();
+    expect(engine.state.buttonSeat).toBe(0);
+
+    // Play to showdown
+    playHandToShowdown(engine);
+
+    // Button should move to seat 1 (dead button at empty seat)
+    engine.deal();
+    expect(engine.state.buttonSeat).toBe(1); // Dead button at empty seat 1
+  });
+
+  test("multiple hands rotation is consistent", () => {
+    const engine = new PokerEngine({
+      smallBlind: 10,
+      bigBlind: 20,
+      maxPlayers: 9,
+    });
+
+    engine.sit(0, "p1", "Alice", 10000);
+    engine.sit(1, "p2", "Bob", 10000);
+
+    const expectedButtons = [0, 1, 0, 1, 0]; // Alternating pattern
+
+    for (let hand = 0; hand < 5; hand++) {
+      engine.deal();
+      expect(engine.state.buttonSeat).toBe(expectedButtons[hand]);
+      playHandToShowdown(engine);
+    }
+  });
+});


### PR DESCRIPTION
When using a 9-seat table with only 2 players at seats 0 and 1, deal() fails on the 3rd hand with `CriticalStateError: ActionTo points to empty seat: 2`. The button should wrap from seat 1 back to seat 0, but the library calculates actionTo incorrectly.
